### PR TITLE
Corrected inertial tensor estimates in urdf

### DIFF
--- a/turtlebot_arm_description/urdf/arm_hardware.xacro
+++ b/turtlebot_arm_description/urdf/arm_hardware.xacro
@@ -11,6 +11,18 @@
   <xacro:property name="AX12_LENGTH" value="0.050"/>
   <xacro:property name="F2_HEIGHT" value="0.0265"/>
 
+  <!-- Calculates the inertial properties of a bounding box. From
+       https://en.wikipedia.org/wiki/List_of_moments_of_inertia#List_of_3D_inertia_tensors-->
+  <xacro:macro name="box_inertia" params="length width height mass">
+    <inertial>
+      <mass value="${mass}"/>
+      <origin xyz="0 0 0"/>
+      <inertia ixx="${mass/12*(height**2+length**2)}" ixy="0" ixz = "0"
+               iyy="${mass/12*(width**2+length**2)}" iyz="0"
+               izz="${mass/12*(width**2+height**2)}"/>
+    </inertial>
+  </xacro:macro>
+
   <xacro:macro name="arm_mount" params="parent name color *origin">
     <joint name="${name}_joint" type="fixed">
       <xacro:insert_block name="origin"/>
@@ -19,13 +31,7 @@
     </joint>
 
     <link name="${name}_link">
-      <inertial>
-        <mass value="0.018"/>
-        <origin xyz="0 0 0"/>
-        <inertia ixx="0.000001" ixy="0.0" ixz="0.0"
-                 iyy="0.000001" iyz="0.0"
-                 izz="0.000001"/>
-      </inertial>
+      <xacro:box_inertia length="0.074" width="0.074" height="0.004" mass="0.018"/>
 
       <visual>
         <origin xyz="-0.028 -0.0493 0.014" rpy="0.0 0.0 -${M_PI/2}"/>
@@ -58,13 +64,7 @@
     </joint>
 
     <link name="${name}_link">
-      <inertial>
-        <mass value="0.015"/>
-        <origin xyz="0 0 0"/>
-        <inertia ixx="0.000001" ixy="0.0" ixz="0.0"
-                 iyy="0.000001" iyz="0.0"
-                 izz="0.000001"/>
-      </inertial>
+      <xacro:box_inertia length="0.0783" width="0.03801" height="0.0193" mass="0.015"/>
 
       <visual>
         <origin xyz=" 0 0 0 " rpy="0 0 0"/>
@@ -136,13 +136,7 @@
     </joint>
 
     <link name="${name}_link">
-      <inertial>
-        <mass value="0.004"/>
-        <origin xyz="0 0 0"/>
-        <inertia ixx="0.000001" ixy="0.0" ixz="0.0"
-                 iyy="0.000001" iyz="0.0"
-                 izz="0.000001"/>
-      </inertial>
+      <xacro:box_inertia length="0.025" width="0.038" height="0.004" mass="0.004"/>
 
       <visual>
         <origin xyz=" 0 0 0 " rpy="0 0 0"/>
@@ -175,13 +169,7 @@
     </joint>
 
     <link name="${name}_link">
-      <inertial>
-        <mass value="0.005"/>
-        <origin xyz="0 0 0"/>
-        <inertia ixx="0.000001" ixy="0.0" ixz="0.0"
-                 iyy="0.000001" iyz="0.0"
-                 izz="0.000001"/>
-      </inertial>
+      <xacro:box_inertia length="0.025" width="0.038" height="0.009" mass="0.005"/>
 
       <visual>
         <origin xyz=" 0 0 0 " rpy="0 0 0"/>
@@ -217,13 +205,7 @@
     </joint>
 
     <link name="${name}_link">
-      <inertial>
-        <mass value="0.008"/>
-        <origin xyz="0 0 0"/>
-        <inertia ixx="0.000001" ixy="0.0" ixz="0.0"
-                 iyy="0.000001" iyz="0.0"
-                 izz="0.000001"/>
-      </inertial>
+      <xacro:box_inertia length="0.025" width="0.038" height="0.009" mass="0.008"/>
 
       <visual>
         <origin xyz=" 0 0 0 " rpy="0 0 0"/>
@@ -259,13 +241,7 @@
     </joint>
 
     <link name="${name}_link">
-      <inertial>
-        <mass value="0.010"/>
-        <origin xyz="0 0 0"/>
-        <inertia ixx="0.000001" ixy="0.0" ixz="0.0"
-                 iyy="0.000001" iyz="0.0"
-                 izz="0.000001"/>
-      </inertial>
+      <xacro:box_inertia length="0.025" width="0.0485" height="0.0375" mass="0.010"/>
 
       <visual>
         <origin xyz=" 0 0 0 " rpy="0 0 0"/>
@@ -301,13 +277,7 @@
     </joint>
 
     <link name="${name}_link">
-      <inertial>
-        <mass value="0.016"/>
-        <origin xyz="0 0 0"/>
-        <inertia ixx="0.000001" ixy="0.0" ixz="0.0"
-                 iyy="0.000001" iyz="0.0"
-                 izz="0.000001"/>
-      </inertial>
+      <xacro:box_inertia length="0.028" width="0.0485" height="0.065" mass="0.016"/>
 
       <visual>
         <origin xyz=" 0 0 0 " rpy="0 0 0"/>
@@ -340,13 +310,7 @@
     </joint>
     
     <link name="${name}_link">
-      <inertial>
-        <mass value="0.00001"/>
-        <origin xyz="0 0 0"/>
-        <inertia ixx="1.0" ixy="0.0" ixz="0.0"
-          iyy="1.0" iyz="0.0"
-          izz="1.0"/>
-      </inertial>
+      <xacro:box_inertia length="0.002" width="0.040" height="0.075" mass="0.00001"/>
       <visual>
         <origin xyz="0.016 0 -.015 " rpy="${M_PI} ${-M_PI/2} ${M_PI/2}"/>
         <geometry>
@@ -372,13 +336,7 @@
   
     <xacro:macro name="pincher_gripper" params="name color *origin">
       <link name="${name}_link">
-      <inertial>
-        <mass value="0.00001"/>
-        <origin xyz="0 0 0"/>
-        <inertia ixx="1.0" ixy="0.0" ixz="0.0"
-          iyy="1.0" iyz="0.0"
-          izz="1.0"/>
-      </inertial>
+      <xacro:box_inertia length="0.036" width="0.028" height="0.004" mass="0.00001"/>
       <visual>
         <xacro:insert_block name="origin"/>
         <geometry>

--- a/turtlebot_arm_description/urdf/pincher_arm.urdf
+++ b/turtlebot_arm_description/urdf/pincher_arm.urdf
@@ -5,10 +5,7 @@
 <!-- =================================================================================== -->
 <!-- Describe URDF for PhantomX Pincher Arm -->
 <robot name="turtlebot_arm" xmlns:xacro="http://ros.org/wiki/xacro">
-  <!-- We can configure joints velocity limit and lower/upper limits
-          to allow access to different operational areas, e.g. left handed vs. right handed robot -->
   <!-- Included URDF Files -->
-  <!-- Pincher arm is same as Turtlebot -->
   <material name="White">
     <color rgba="0.87 0.90 0.87 1.0"/>
   </material>
@@ -23,13 +20,15 @@
   </material>
   <!-- As we don't have here a turtlebot base, add a base_link link as its location reference -->
   <link name="base_link"/>
-  <!-- Turtlebot arm macro -->
   <link name="arm_base_link"/>
   <joint name="arm_base_joint" type="fixed">
     <origin xyz="0.1 0.03 0.435"/>
     <parent link="base_link"/>
     <child link="arm_base_link"/>
   </joint>
+  <!-- fake gripper_link joint gives us a free servo!
+         this makes us 5DOF and saves you $44.90
+         that's a lot of coin! -->
   <link name="gripper_link"/>
   <joint name="gripper_link_joint" type="revolute">
     <origin rpy="0 -1.57 0" xyz="0 0 0.112"/>
@@ -54,7 +53,7 @@
       <geometry>
         <mesh filename="package://turtlebot_arm_description/meshes/ax12_box.stl" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="Gray"/>
+      <material name="Black"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.0 0.0 -0.01241"/>
@@ -80,7 +79,7 @@
     <inertial>
       <mass value="0.008"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="4.70666666667e-07" ixy="0" ixz="0" iyy="1.37933333333e-06" iyz="0" izz="1.01666666667e-06"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -117,7 +116,7 @@
       <geometry>
         <mesh filename="package://turtlebot_arm_description/meshes/ax12_box.stl" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="Gray"/>
+      <material name="Black"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.0 0.0 -0.01241"/>
@@ -134,7 +133,7 @@
   <joint name="arm_shoulder_lift_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="0 1 0"/>
-    <limit effort="30" lower="-2.617" upper="2.617" velocity="1.571"/>
+    <limit effort="30" lower="-2.2" upper="2.16" velocity="1.571"/>
     <dynamics friction="0.13"/>
     <parent link="arm_shoulder_lift_servo_link"/>
     <child link="arm_shoulder_lift_link"/>
@@ -143,7 +142,7 @@
     <inertial>
       <mass value="0.016"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="6.67866666667e-06" ixy="0" ixz="0" iyy="4.18166666667e-06" iyz="0" izz="8.76966666667e-06"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -173,7 +172,7 @@
     <inertial>
       <mass value="0.004"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.13666666667e-07" ixy="0" ixz="0" iyy="6.89666666667e-07" iyz="0" izz="4.86666666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -203,7 +202,7 @@
     <inertial>
       <mass value="0.004"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.13666666667e-07" ixy="0" ixz="0" iyy="6.89666666667e-07" iyz="0" izz="4.86666666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -233,7 +232,7 @@
     <inertial>
       <mass value="0.004"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.13666666667e-07" ixy="0" ixz="0" iyy="6.89666666667e-07" iyz="0" izz="4.86666666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -263,7 +262,7 @@
     <inertial>
       <mass value="0.005"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.94166666667e-07" ixy="0" ixz="0" iyy="8.62083333333e-07" iyz="0" izz="6.35416666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -300,7 +299,7 @@
       <geometry>
         <mesh filename="package://turtlebot_arm_description/meshes/ax12_box.stl" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="Gray"/>
+      <material name="Black"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.0 0.0 -0.01241"/>
@@ -317,7 +316,7 @@
   <joint name="arm_elbow_flex_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="0 1 0"/>
-    <limit effort="30" lower="-2.617" upper="2.617" velocity="1.571"/>
+    <limit effort="30" lower="-2.42" upper="2.38" velocity="1.571"/>
     <dynamics friction="0.13"/>
     <parent link="arm_elbow_flex_servo_link"/>
     <child link="arm_elbow_flex_link"/>
@@ -326,7 +325,7 @@
     <inertial>
       <mass value="0.016"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="6.67866666667e-06" ixy="0" ixz="0" iyy="4.18166666667e-06" iyz="0" izz="8.76966666667e-06"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -356,7 +355,7 @@
     <inertial>
       <mass value="0.004"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.13666666667e-07" ixy="0" ixz="0" iyy="6.89666666667e-07" iyz="0" izz="4.86666666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -386,7 +385,7 @@
     <inertial>
       <mass value="0.004"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.13666666667e-07" ixy="0" ixz="0" iyy="6.89666666667e-07" iyz="0" izz="4.86666666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -416,7 +415,7 @@
     <inertial>
       <mass value="0.004"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.13666666667e-07" ixy="0" ixz="0" iyy="6.89666666667e-07" iyz="0" izz="4.86666666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -446,7 +445,7 @@
     <inertial>
       <mass value="0.005"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.94166666667e-07" ixy="0" ixz="0" iyy="8.62083333333e-07" iyz="0" izz="6.35416666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -483,7 +482,7 @@
       <geometry>
         <mesh filename="package://turtlebot_arm_description/meshes/ax12_box.stl" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="Gray"/>
+      <material name="Black"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.0 0.0 -0.01241"/>
@@ -500,16 +499,16 @@
   <joint name="arm_wrist_flex_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="0 1 0"/>
-    <limit effort="30" lower="-1.745" upper="1.745" velocity="1.571"/>
+    <limit effort="30" lower="-1.72" upper="1.68" velocity="1.571"/>
     <dynamics friction="0.13"/>
     <parent link="arm_wrist_flex_servo_link"/>
     <child link="arm_wrist_flex_link"/>
   </joint>
   <link name="arm_wrist_flex_link">
     <inertial>
-      <mass value="0.010"/>
+      <mass value="0.01"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="1.69270833333e-06" ixy="0" ixz="0" iyy="2.48104166667e-06" iyz="0" izz="3.13208333333e-06"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -539,7 +538,7 @@
     <inertial>
       <mass value="0.005"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.94166666667e-07" ixy="0" ixz="0" iyy="8.62083333333e-07" iyz="0" izz="6.35416666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -576,7 +575,7 @@
       <geometry>
         <mesh filename="package://turtlebot_arm_description/meshes/ax12_box.stl" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="Gray"/>
+      <material name="Black"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.0 0.0 -0.01241"/>
@@ -597,9 +596,9 @@
   </joint>
   <link name="gripper_finger_base_link">
     <inertial>
-      <mass value="0.00001"/>
+      <mass value="1e-05"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="4.69083333333e-09" ixy="0" ixz="0" iyy="1.33666666667e-09" iyz="0" izz="6.02083333333e-09"/>
     </inertial>
     <visual>
       <origin rpy="3.14159 -1.570795 1.570795" xyz="0.016 0 -.015 "/>
@@ -620,6 +619,7 @@
     <selfCollide>true</selfCollide>
     <gravity>true</gravity>
   </gazebo>
+  <!-- Finger 1 -->
   <joint name="gripper_joint" type="prismatic">
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="1 0 0"/>
@@ -629,9 +629,9 @@
   </joint>
   <link name="gripper_active_link">
     <inertial>
-      <mass value="0.00001"/>
+      <mass value="1e-05"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="1.09333333333e-09" ixy="0" ixz="0" iyy="1.73333333333e-09" iyz="0" izz="6.66666666667e-10"/>
     </inertial>
     <visual>
       <origin rpy="-1.570795 0 0" xyz="-0.02 0.023 0"/>
@@ -652,15 +652,17 @@
     <selfCollide>true</selfCollide>
     <gravity>true</gravity>
   </gazebo>
+  <!-- Finger 2 -->
+  <!-- Note: currently static but should be a Mimic of Finger 1 -->
   <joint name="gripper2_joint" type="fixed">
     <parent link="gripper_servo_link"/>
     <child link="gripper_active2_link"/>
   </joint>
   <link name="gripper_active2_link">
     <inertial>
-      <mass value="0.00001"/>
+      <mass value="1e-05"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="1.09333333333e-09" ixy="0" ixz="0" iyy="1.73333333333e-09" iyz="0" izz="6.66666666667e-10"/>
     </inertial>
     <visual>
       <origin rpy="-1.570795 3.14159 0" xyz="-0.02 0.023 0"/>
@@ -681,5 +683,15 @@
     <selfCollide>true</selfCollide>
     <gravity>true</gravity>
   </gazebo>
+  <!-- Using Mimic -->
+  <!-- gripper 2 joint -->
+  <!--  ### Mimic would be better but causes Missing Joint error in Moveit 
+      <joint name="gripper2_joint" type="prismatic">
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <axis xyz="0 0 1"/>
+      <limit effort="30" velocity="0.5" lower="0.002" upper="0.031"/>
+      <parent link="gripper_servo_link"/>
+      <child link="gripper_active2_link"/>
+      <mimic joint="gripper_joint" multiplier="-.5"  offset = "0"/>
+    </joint-->
 </robot>
-

--- a/turtlebot_arm_description/urdf/turtlebot_arm.urdf
+++ b/turtlebot_arm_description/urdf/turtlebot_arm.urdf
@@ -5,9 +5,6 @@
 <!-- =================================================================================== -->
 <!-- Describe URDF for Turtlebot Arm -->
 <robot name="turtlebot_arm" xmlns:xacro="http://ros.org/wiki/xacro">
-  <!-- We can configure joints velocity limit and lower/upper limits
-          to allow access to different operational areas, e.g. left handed vs. right handed robot -->
-  <!-- Included URDF Files -->
   <material name="White">
     <color rgba="0.87 0.90 0.87 1.0"/>
   </material>
@@ -22,13 +19,15 @@
   </material>
   <!-- As we don't have here a turtlebot base, add a base_link link as its location reference -->
   <link name="base_link"/>
-  <!-- Turtlebot arm macro -->
   <link name="arm_base_link"/>
   <joint name="arm_base_joint" type="fixed">
     <origin xyz="0.1 0.03 0.435"/>
     <parent link="base_link"/>
     <child link="arm_base_link"/>
   </joint>
+  <!-- fake gripper_link joint gives us a free servo!
+         this makes us 5DOF and saves you $44.90
+         that's a lot of coin! -->
   <link name="gripper_link"/>
   <joint name="gripper_link_joint" type="revolute">
     <origin rpy="0 -1.57 0" xyz="0 0 0.112"/>
@@ -53,7 +52,7 @@
       <geometry>
         <mesh filename="package://turtlebot_arm_description/meshes/ax12_box.stl" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="White"/>
+      <material name="Black"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.0 0.0 -0.01241"/>
@@ -79,7 +78,7 @@
     <inertial>
       <mass value="0.008"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="4.70666666667e-07" ixy="0" ixz="0" iyy="1.37933333333e-06" iyz="0" izz="1.01666666667e-06"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -116,7 +115,7 @@
       <geometry>
         <mesh filename="package://turtlebot_arm_description/meshes/ax12_box.stl" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="White"/>
+      <material name="Black"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.0 0.0 -0.01241"/>
@@ -142,7 +141,7 @@
     <inertial>
       <mass value="0.016"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="6.67866666667e-06" ixy="0" ixz="0" iyy="4.18166666667e-06" iyz="0" izz="8.76966666667e-06"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -172,7 +171,7 @@
     <inertial>
       <mass value="0.004"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.13666666667e-07" ixy="0" ixz="0" iyy="6.89666666667e-07" iyz="0" izz="4.86666666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -202,7 +201,7 @@
     <inertial>
       <mass value="0.004"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.13666666667e-07" ixy="0" ixz="0" iyy="6.89666666667e-07" iyz="0" izz="4.86666666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -232,7 +231,7 @@
     <inertial>
       <mass value="0.004"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.13666666667e-07" ixy="0" ixz="0" iyy="6.89666666667e-07" iyz="0" izz="4.86666666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -262,7 +261,7 @@
     <inertial>
       <mass value="0.005"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.94166666667e-07" ixy="0" ixz="0" iyy="8.62083333333e-07" iyz="0" izz="6.35416666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -299,7 +298,7 @@
       <geometry>
         <mesh filename="package://turtlebot_arm_description/meshes/ax12_box.stl" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="White"/>
+      <material name="Black"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.0 0.0 -0.01241"/>
@@ -325,7 +324,7 @@
     <inertial>
       <mass value="0.016"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="6.67866666667e-06" ixy="0" ixz="0" iyy="4.18166666667e-06" iyz="0" izz="8.76966666667e-06"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -355,7 +354,7 @@
     <inertial>
       <mass value="0.004"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.13666666667e-07" ixy="0" ixz="0" iyy="6.89666666667e-07" iyz="0" izz="4.86666666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -385,7 +384,7 @@
     <inertial>
       <mass value="0.004"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.13666666667e-07" ixy="0" ixz="0" iyy="6.89666666667e-07" iyz="0" izz="4.86666666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -415,7 +414,7 @@
     <inertial>
       <mass value="0.004"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.13666666667e-07" ixy="0" ixz="0" iyy="6.89666666667e-07" iyz="0" izz="4.86666666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -445,7 +444,7 @@
     <inertial>
       <mass value="0.005"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.94166666667e-07" ixy="0" ixz="0" iyy="8.62083333333e-07" iyz="0" izz="6.35416666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -482,7 +481,7 @@
       <geometry>
         <mesh filename="package://turtlebot_arm_description/meshes/ax12_box.stl" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="White"/>
+      <material name="Black"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.0 0.0 -0.01241"/>
@@ -506,9 +505,9 @@
   </joint>
   <link name="arm_wrist_flex_link">
     <inertial>
-      <mass value="0.010"/>
+      <mass value="0.01"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="1.69270833333e-06" ixy="0" ixz="0" iyy="2.48104166667e-06" iyz="0" izz="3.13208333333e-06"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -538,7 +537,7 @@
     <inertial>
       <mass value="0.005"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.94166666667e-07" ixy="0" ixz="0" iyy="8.62083333333e-07" iyz="0" izz="6.35416666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -575,7 +574,7 @@
       <geometry>
         <mesh filename="package://turtlebot_arm_description/meshes/ax12_box.stl" scale="0.001 0.001 0.001"/>
       </geometry>
-      <material name="White"/>
+      <material name="Black"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0.0 0.0 -0.01241"/>
@@ -589,6 +588,7 @@
     <selfCollide>true</selfCollide>
     <gravity>true</gravity>
   </gazebo>
+  <!-- finger 1 -->
   <joint name="gripper_joint" type="revolute">
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="0 1 0"/>
@@ -625,7 +625,7 @@
     <inertial>
       <mass value="0.015"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="8.129225e-06" ixy="0" ixz="0" iyy="9.469562625e-06" iyz="0" izz="2.271562625e-06"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -655,7 +655,7 @@
     <inertial>
       <mass value="0.005"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="2.94166666667e-07" ixy="0" ixz="0" iyy="8.62083333333e-07" iyz="0" izz="6.35416666667e-07"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -685,7 +685,7 @@
     <inertial>
       <mass value="0.015"/>
       <origin xyz="0 0 0"/>
-      <inertia ixx="0.000001" ixy="0.0" ixz="0.0" iyy="0.000001" iyz="0.0" izz="0.000001"/>
+      <inertia ixx="8.129225e-06" ixy="0" ixz="0" iyy="9.469562625e-06" iyz="0" izz="2.271562625e-06"/>
     </inertial>
     <visual>
       <origin rpy="0 0 0" xyz=" 0 0 0 "/>
@@ -707,4 +707,3 @@
     <gravity>true</gravity>
   </gazebo>
 </robot>
-


### PR DESCRIPTION
Many of the inertial values in `turtlebot_arm_description/urdf/arm_hardware.xacro` are incorrect. For the most part the values are small and the error negiligable, but the values for the gripper `ixx="1.0"...` were simulation breaking. I added a macro that generates appropriate values based on dimensions of a bounding box and went ahead and replaced all of the hardware inertial tags with the macro, using the size of the collision boxes.