### PR TITLE
Fixed build failure on new clone

### DIFF
--- a/turtlebot_arm_block_manipulation/CMakeLists.txt
+++ b/turtlebot_arm_block_manipulation/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(turtlebot_arm_block_manipulation)
 
+add_definitions(-std=c++11)
+
 # setup
 find_package(catkin REQUIRED actionlib actionlib_msgs interactive_markers pcl_ros roscpp visualization_msgs moveit_core moveit_ros_planning_interface)
 find_package(Boost REQUIRED system filesystem)

--- a/turtlebot_arm_ikfast_plugin/CMakeLists.txt
+++ b/turtlebot_arm_ikfast_plugin/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(turtlebot_arm_ikfast_plugin)
 
+add_definitions(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS
   cmake_modules
   moveit_core


### PR DESCRIPTION
In what is possibly one of the fastest turnaround times from issue to pull request in the history of open source, this fixes #25 by adding the C++11 flag to both packages.